### PR TITLE
Changed parameter type used by TargetEndpint.Wake() to native byte[]

### DIFF
--- a/WakeDevice/Program.cs
+++ b/WakeDevice/Program.cs
@@ -11,10 +11,10 @@ try
     MagicPacket Packet = new(Endpoint.Mac);
     if (Command.Repetitions == null)
     {
-        Endpoint.Wake(Packet);
+        Endpoint.Wake(Packet.Payload);
         return;
     }
-    Endpoint.Wake(Packet, Command.Repetitions);
+    Endpoint.Wake(Packet.Payload, Command.Repetitions);
 }
 catch (Exception ex)
 {

--- a/WakeDevice/TargetEndpoint.cs
+++ b/WakeDevice/TargetEndpoint.cs
@@ -118,7 +118,7 @@ namespace WakeDevice
         /// </summary>
         /// <param name="packet"></param>
         /// <param name="repetitions"></param>
-        public void Wake(MagicPacket packet, uint? repetitions = 5)
+        public void Wake(byte[] packet, uint? repetitions = 5)
         {
             Socket s = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
 
@@ -130,7 +130,7 @@ namespace WakeDevice
                 for (int i = 0; i < repetitions; i++)
                 {
                     // Send data to destination host
-                    s.SendTo(packet.Payload, EndPoint);
+                    s.SendTo(packet, EndPoint);
                 }
 
                 Console.WriteLine();


### PR DESCRIPTION
Tight coupling has been removed by changing TargetEndpoint.Wake() parameter to a native type.