### PR TITLE
Refactorization target endpoint

### DIFF
--- a/WakeDevice/TargetEndpoint.cs
+++ b/WakeDevice/TargetEndpoint.cs
@@ -122,9 +122,10 @@ namespace WakeDevice
         {
             Socket s = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
 
+            IPAddress DestinationAddress = GetBroadcastAddress();
+
             foreach (var port in AddressPorts)
             {
-                IPAddress DestinationAddress = GetBroadcastAddress();
                 IPEndPoint EndPoint = new(DestinationAddress, (int)port);
 
                 for (int i = 0; i < repetitions; i++)

--- a/WakeDevice/TargetEndpoint.cs
+++ b/WakeDevice/TargetEndpoint.cs
@@ -16,7 +16,7 @@ namespace WakeDevice
     {
         #region Fields
         private IPAddress _addressIP;
-        private IPAddress _addressMask = IPAddress.Parse("255.255.255.0");
+        private IPAddress _addressMask = IPAddress.Parse("255.255.255.255");
         private List<uint> _addressPorts = new() { 7, 9 };
         private PhysicalAddress _mac;
         #endregion;


### PR DESCRIPTION
Method call:
Made code closer to optimal by moving `GetBroadcastAddress()` method call outside a `foreach`. It was unnecessarily called for each element of AddressPorts array. Now it's only called once for an endpoint.

Subnet Mask:
Formerly, default subnet mask value was "255.255.255.0" which (for a typical LAN address like 192.168.0.1) caused a magic packet to be sent to broadcast address. As this is not always wanted and often does not work (due to network security) it has been changed to "255.255.255.255". Now the IP address provided as program argument is targeted directly, unless a different subnet mask is explicitly specified.